### PR TITLE
[Bugfix] Expose know standard gestures to consumers in android

### DIFF
--- a/demo-ng/app/imageswipe/imageswipe.component.html
+++ b/demo-ng/app/imageswipe/imageswipe.component.html
@@ -1,7 +1,7 @@
 <ActionBar title="Demo NG" class="action-bar">
 </ActionBar>
 <GridLayout>
-    <ImageSwipe [items]="items" imageUrlProperty="imageUrl" 
+    <ImageSwipe [items]="items" imageUrlProperty="imageUrl" (tap)="tapped()"
                 [pageNumber]="pageNumber" (pageChanged)="pageChanged($event)" backgroundColor="#000000">
     </ImageSwipe>
 </GridLayout>

--- a/demo-ng/app/imageswipe/imageswipe.component.ts
+++ b/demo-ng/app/imageswipe/imageswipe.component.ts
@@ -18,6 +18,10 @@ export class ImageSwipeComponent implements OnInit {
         this.items.push({ imageUrl: "http://voices.nationalgeographic.com/files/2013/04/NationalGeographic_1329449.jpg" });
     }
 
+    public tapped() {
+        console.log("tapped");
+    }
+
     public pageChanged(e: PageChangeEventData) {
         console.log(`Page changed to ${e.page}.`);
     }

--- a/image-swipe.android.ts
+++ b/image-swipe.android.ts
@@ -13,12 +13,23 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ***************************************************************************** */
+import { GestureTypes } from "ui/gestures";
 import { ImageSwipeBase, itemsProperty, pageNumberProperty } from "./image-swipe-common";
 
 // These constants specify the mode that we're in
 const MODE_NONE = 0;
 const MODE_DRAG = 1;
 const MODE_ZOOM = 2;
+const ALL_GESTURE_TYPES: GestureTypes[] = [
+    GestureTypes.doubleTap,
+    GestureTypes.longPress,
+    GestureTypes.pan,
+    GestureTypes.pinch,
+    GestureTypes.rotation,
+    GestureTypes.swipe,
+    GestureTypes.tap,
+    GestureTypes.touch
+];
 
 export * from "./image-swipe-common";
 
@@ -151,7 +162,7 @@ class ImageSwipePageAdapter extends android.support.v4.view.PagerAdapter {
         params.height = android.view.ViewGroup.LayoutParams.MATCH_PARENT;
         params.width = android.view.ViewGroup.LayoutParams.MATCH_PARENT;
 
-        const imageView = new ZoomImageView(owner._context);
+        const imageView = new ZoomImageView(owner, owner._context);
         imageView.setLayoutParams(params);
         imageView.setTag("Item" + position.toString());
 
@@ -233,7 +244,7 @@ class ZoomImageView extends android.widget.ImageView {
     private _orientationChangeListener: OrientationListener;
     private _onCanScrollChangeListener: OnCanScrollChangeListenerImplementation;
 
-    constructor(context: android.content.Context) {
+    constructor(private _host: ImageSwipe, context: android.content.Context) {
         super(context);
 
         const that = new WeakRef(this);
@@ -261,7 +272,7 @@ class ZoomImageView extends android.widget.ImageView {
         this.reset();
     }
 
-    public onTouchEvent(event: android.view.MotionEvent): boolean {
+    public onTouchEvent(event: android.view.MotionEvent): boolean {       
         switch (event.getActionMasked()) {
             case android.view.MotionEvent.ACTION_DOWN:
                 this._mode = MODE_DRAG;
@@ -353,6 +364,12 @@ class ZoomImageView extends android.widget.ImageView {
         if ((this._mode === MODE_DRAG && this._dragged)
             || this._mode === MODE_ZOOM) {
             this.invalidate();
+        }
+
+        for (const gestureType of ALL_GESTURE_TYPES) {
+            for (const observer of this._host.getGestureObservers(gestureType) || []) {
+                observer.androidOnTouchEvent(event);
+            }
         }
 
         return true;

--- a/image-swipe.android.ts
+++ b/image-swipe.android.ts
@@ -162,7 +162,7 @@ class ImageSwipePageAdapter extends android.support.v4.view.PagerAdapter {
         params.height = android.view.ViewGroup.LayoutParams.MATCH_PARENT;
         params.width = android.view.ViewGroup.LayoutParams.MATCH_PARENT;
 
-        const imageView = new ZoomImageView(owner, owner._context);
+        const imageView = new ZoomImageView(this.owner);
         imageView.setLayoutParams(params);
         imageView.setTag("Item" + position.toString());
 
@@ -244,9 +244,10 @@ class ZoomImageView extends android.widget.ImageView {
     private _orientationChangeListener: OrientationListener;
     private _onCanScrollChangeListener: OnCanScrollChangeListenerImplementation;
 
-    constructor(private _host: ImageSwipe, context: android.content.Context) {
-        super(context);
+    constructor(private _owner: WeakRef<ImageSwipe>) {
+        super(_owner.get()._context);
 
+        const context = _owner.get()._context;
         const that = new WeakRef(this);
         this._detector = new android.view.ScaleGestureDetector(context, new android.view.ScaleGestureDetector.OnScaleGestureListener({
             onScale: (detector: android.view.ScaleGestureDetector): boolean => {
@@ -366,8 +367,9 @@ class ZoomImageView extends android.widget.ImageView {
             this.invalidate();
         }
 
+        const owner = this._owner.get();
         for (const gestureType of ALL_GESTURE_TYPES) {
-            for (const observer of this._host.getGestureObservers(gestureType) || []) {
+            for (const observer of owner.getGestureObservers(gestureType) || []) {
                 observer.androidOnTouchEvent(event);
             }
         }


### PR DESCRIPTION
This is working fine with the ScrollView parent in iOS but not on Android because the implementation of `onTouchEvent()` fully consumes the event. 

I added a delegation to the GestureObeservers attached to the ImageSwipe component itself.