### PR TITLE
added a null check in the onOrientationChanged() listener implementation

### DIFF
--- a/image-swipe.android.ts
+++ b/image-swipe.android.ts
@@ -481,7 +481,10 @@ class OrientationListener extends android.view.OrientationEventListener {
     }
 
     public onOrientationChanged(orientation: number) {
-        this._zoomImageView.get().reset(true);
+        const zoomImageView: ZoomImageView = this._zoomImageView.get();
+        if (zoomImageView) {
+            zoomImageView.reset(true);
+        }
     }
 }
 


### PR DESCRIPTION
We got this stacktrace from Google Play. Code analysis showed that the fixed place is the only usage of a `reset()` in all `onOrientationChanged`. 
```com.tns.NativeScriptException: 
Calling js method onOrientationChanged
 failed
TypeError: Cannot read property 'reset' of null
File: "file:///data/data/<customers bundle id>/files/app/bundle.js, line: 916, column: 9328
StackTrace: 
	Frame: function:'OrientationListener.onOrientationChanged', file:'file:///data/data/<customers bundle id>/files/app/bundle.js', line: 916, column: 9329
	at com.tns.Runtime.callJSMethodNative(Native Method)
	at com.tns.Runtime.dispatchCallJSMethodNative(Runtime.java:1043)
	at com.tns.Runtime.callJSMethodImpl(Runtime.java:925)
	at com.tns.Runtime.callJSMethod(Runtime.java:912)
	at com.tns.Runtime.callJSMethod(Runtime.java:896)
	at com.tns.Runtime.callJSMethod(Runtime.java:888)
	at com.tns.gen.android.view.OrientationEventListener_frnal_ts_helpers_l58_c38__OrientationListener.onOrientationChanged(OrientationEventListener_frnal_ts_helpers_l58_c38__OrientationListener.java:17)
	at android.view.OrientationEventListener$SensorEventListenerImpl.onSensorChanged(OrientationEventListener.java:143)
	at android.hardware.SystemSensorManager$SensorEventQueue.dispatchSensorEvent(SystemSensorManager.java:824)
	at android.os.MessageQueue.nativePollOnce(Native Method)
	at android.os.MessageQueue.next(MessageQueue.java:323)
	at android.os.Looper.loop(Looper.java:136)
	at android.app.ActivityThread.main(ActivityThread.java:6692)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1468)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1358)
```