### PR TITLE
Update onOrientationChanged for Android to identify the 4 main orientations.

### DIFF
--- a/image-swipe.android.ts
+++ b/image-swipe.android.ts
@@ -30,10 +30,12 @@ const ALL_GESTURE_TYPES: GestureTypes[] = [
     GestureTypes.tap,
     GestureTypes.touch
 ];
-const ORIENTATION_PORTRAIT = 0;
-const ORIENTATION_LANDSCAPE = 1;
-const ORIENTATION_PORTRAIT_REVERSE = 2;
-const ORIENTATION_LANDSCAPE_REVERSE = 3;
+const enum Orientation {
+    Portrait = 0,
+    Landscape = 1,
+    PortraitReverse = 2,
+    LandscapeReverse = 3,
+}
 
 export * from "./image-swipe-common";
 
@@ -475,13 +477,13 @@ class ZoomImageView extends android.widget.ImageView {
 
 class OrientationListener extends android.view.OrientationEventListener {
     private _zoomImageView: WeakRef<ZoomImageView>;
-    private _previousOrientation: number;
+    private _previousOrientation: Orientation;
 
     constructor(context: android.content.Context, zoomImageView: WeakRef<ZoomImageView>) {
         super(context);
 
         this._zoomImageView = zoomImageView;
-        this._previousOrientation = ORIENTATION_PORTRAIT;
+        this._previousOrientation = Orientation.Portrait;
 
         return __native(this);
     }
@@ -489,25 +491,25 @@ class OrientationListener extends android.view.OrientationEventListener {
     public onOrientationChanged(orientation: number) {
         const zoomImageView: ZoomImageView = this._zoomImageView.get();
         let orientationChanged = false;
-        let currentOrientation;
+        let currentOrientation: Orientation;
 
         if (orientation <= 45) {
-            currentOrientation = ORIENTATION_PORTRAIT;
+            currentOrientation = Orientation.Portrait;
         } else if (orientation <= 135) {
-            currentOrientation = ORIENTATION_LANDSCAPE_REVERSE;
+            currentOrientation = Orientation.LandscapeReverse;
         } else if (orientation <= 225) {
-            currentOrientation = ORIENTATION_PORTRAIT_REVERSE;
+            currentOrientation = Orientation.PortraitReverse;
         } else if (orientation <= 315) {
-            currentOrientation = ORIENTATION_LANDSCAPE;
+            currentOrientation = Orientation.Landscape;
         } else {
-            currentOrientation = ORIENTATION_PORTRAIT;
+            currentOrientation = Orientation.Portrait;
         }
-        
+
         if (currentOrientation !== this._previousOrientation) {
             this._previousOrientation = currentOrientation;
             orientationChanged = true;
         }
-        
+
         if (zoomImageView && orientationChanged) {
             zoomImageView.reset(true);
         }

--- a/image-swipe.android.ts
+++ b/image-swipe.android.ts
@@ -35,7 +35,6 @@ const ORIENTATION_LANDSCAPE = 1;
 const ORIENTATION_PORTRAIT_REVERSE = 2;
 const ORIENTATION_LANDSCAPE_REVERSE = 3;
 
-
 export * from "./image-swipe-common";
 
 export class ImageSwipe extends ImageSwipeBase {
@@ -489,8 +488,8 @@ class OrientationListener extends android.view.OrientationEventListener {
 
     public onOrientationChanged(orientation: number) {
         const zoomImageView: ZoomImageView = this._zoomImageView.get();
-        var orientationChanged = false;
-        var currentOrientation;
+        let orientationChanged = false;
+        let currentOrientation;
 
         if (orientation <= 45) {
             currentOrientation = ORIENTATION_PORTRAIT;
@@ -504,7 +503,7 @@ class OrientationListener extends android.view.OrientationEventListener {
             currentOrientation = ORIENTATION_PORTRAIT;
         }
         
-        if (currentOrientation != this._previousOrientation) {
+        if (currentOrientation !== this._previousOrientation) {
             this._previousOrientation = currentOrientation;
             orientationChanged = true;
         }

--- a/image-swipe.android.ts
+++ b/image-swipe.android.ts
@@ -124,6 +124,11 @@ class ImageSwipePageChangeListener extends java.lang.Object implements android.s
         if (preloadedImageView) {
             preloadedImageView.reset();
         }
+        
+        preloadedImageView = owner.android.findViewWithTag("Item" + (index + 1).toString()) as ZoomImageView;
+        if (preloadedImageView) {
+            preloadedImageView.reset();
+        }
     }
 
     public onPageScrolled() {
@@ -505,7 +510,6 @@ class OrientationListener extends android.view.OrientationEventListener {
         }
         
         if (zoomImageView && orientationChanged) {
-            // ToDo: Rotate the image based on currentOrientation?
             zoomImageView.reset(true);
         }
     }

--- a/image-swipe.android.ts
+++ b/image-swipe.android.ts
@@ -30,6 +30,11 @@ const ALL_GESTURE_TYPES: GestureTypes[] = [
     GestureTypes.tap,
     GestureTypes.touch
 ];
+const ORIENTATION_PORTRAIT = 0;
+const ORIENTATION_LANDSCAPE = 1;
+const ORIENTATION_PORTRAIT_REVERSE = 2;
+const ORIENTATION_LANDSCAPE_REVERSE = 3;
+
 
 export * from "./image-swipe-common";
 
@@ -116,11 +121,6 @@ class ImageSwipePageChangeListener extends java.lang.Object implements android.s
         let preloadedImageView: ZoomImageView;
 
         preloadedImageView = owner.android.findViewWithTag("Item" + (index - 1).toString()) as ZoomImageView;
-        if (preloadedImageView) {
-            preloadedImageView.reset();
-        }
-
-        preloadedImageView = owner.android.findViewWithTag("Item" + (index + 1).toString()) as ZoomImageView;
         if (preloadedImageView) {
             preloadedImageView.reset();
         }
@@ -471,18 +471,41 @@ class ZoomImageView extends android.widget.ImageView {
 
 class OrientationListener extends android.view.OrientationEventListener {
     private _zoomImageView: WeakRef<ZoomImageView>;
+    private _previousOrientation: number;
 
     constructor(context: android.content.Context, zoomImageView: WeakRef<ZoomImageView>) {
         super(context);
 
         this._zoomImageView = zoomImageView;
+        this._previousOrientation = ORIENTATION_PORTRAIT;
 
         return __native(this);
     }
 
     public onOrientationChanged(orientation: number) {
         const zoomImageView: ZoomImageView = this._zoomImageView.get();
-        if (zoomImageView) {
+        var orientationChanged = false;
+        var currentOrientation;
+
+        if (orientation <= 45) {
+            currentOrientation = ORIENTATION_PORTRAIT;
+        } else if (orientation <= 135) {
+            currentOrientation = ORIENTATION_LANDSCAPE_REVERSE;
+        } else if (orientation <= 225) {
+            currentOrientation = ORIENTATION_PORTRAIT_REVERSE;
+        } else if (orientation <= 315) {
+            currentOrientation = ORIENTATION_LANDSCAPE;
+        } else {
+            currentOrientation = ORIENTATION_PORTRAIT;
+        }
+        
+        if (currentOrientation != this._previousOrientation) {
+            this._previousOrientation = currentOrientation;
+            orientationChanged = true;
+        }
+        
+        if (zoomImageView && orientationChanged) {
+            // ToDo: Rotate the image based on currentOrientation?
             zoomImageView.reset(true);
         }
     }

--- a/image-swipe.android.ts
+++ b/image-swipe.android.ts
@@ -34,7 +34,7 @@ const enum Orientation {
     Portrait = 0,
     Landscape = 1,
     PortraitReverse = 2,
-    LandscapeReverse = 3,
+    LandscapeReverse = 3
 }
 
 export * from "./image-swipe-common";


### PR DESCRIPTION
I am suggesting 2 changes.

1. ~~preloadedImageView assignment looks like it was duplicated, I removed the duplicate.~~
2. onOrientationChanged is resetting the zoomImageView every time the device is moved 1 degree in either axis.  Orientation is changing by the degree, but actual orientation change should be detected more coarsely.  My suggested change is to capture the actual orientation change based on 4 preset orientations, portrait, landscape, portrait-reversed, landscape-reversed and only reset the zoomImageView on those captured changes.

~~In the future, may we can add image rotation using this methodology.~~

Please let me know if you have any questions or suggestions.

Thank you!

Justin