### PR TITLE
Allow for Safe Area Insets for iPhone X, etc.

### DIFF
--- a/image-swipe.android.ts
+++ b/image-swipe.android.ts
@@ -147,7 +147,7 @@ class StateViewPager extends android.support.v4.view.ViewPager {
     constructor(context: android.content.Context) {
         super(context);
 
-        return __native(this);
+        return global.__native(this);
     }
 
     public onInterceptTouchEvent(event: android.view.MotionEvent): boolean {
@@ -279,7 +279,7 @@ class ZoomImageView extends android.widget.ImageView {
         this._orientationChangeListener = new OrientationListener(context, that);
         this._orientationChangeListener.enable();
 
-        return __native(this);
+        return global.__native(this);
     }
 
     public setImageBitmap(image: android.graphics.Bitmap) {
@@ -485,7 +485,7 @@ class OrientationListener extends android.view.OrientationEventListener {
         this._zoomImageView = zoomImageView;
         this._previousOrientation = Orientation.Portrait;
 
-        return __native(this);
+        return global.__native(this);
     }
 
     public onOrientationChanged(orientation: number) {
@@ -528,7 +528,7 @@ class OnCanScrollChangeListener extends java.lang.Object implements OnCanScrollC
 
         this._implementation = implementation;
 
-        return __native(this);
+        return global.__native(this);
     }
 
     public onCanScrollChanged(canScroll: boolean) {

--- a/image-swipe.ios.ts
+++ b/image-swipe.ios.ts
@@ -299,9 +299,12 @@ export class ImageSwipe extends ImageSwipeBase {
         const scrollView: UIScrollView = this.ios;
         const width = utils.layout.toDeviceIndependentPixels(this.getMeasuredWidth());
         const height = utils.layout.toDeviceIndependentPixels(this.getMeasuredHeight());
+        const safeAreaInsets = this.getSafeAreaInsets();
+        const insetAllowance = utils.layout.toDeviceIndependentPixels(safeAreaInsets.left) * 2;
+        const calculatedWidth = width + insetAllowance;
 
-        // console.log(`_calcScrollViewContentSize ${width}, ${height}`);
-        scrollView.contentSize = CGSizeMake(this.items.length * width, height);
+        // console.log(`_calcScrollViewContentSize ${calculatedWidth}, ${height}`);
+        scrollView.contentSize = CGSizeMake(this.items.length * calculatedWidth, height);
     }
 }
 

--- a/image-swipe.ios.ts
+++ b/image-swipe.ios.ts
@@ -300,7 +300,7 @@ export class ImageSwipe extends ImageSwipeBase {
         const width = utils.layout.toDeviceIndependentPixels(this.getMeasuredWidth());
         const height = utils.layout.toDeviceIndependentPixels(this.getMeasuredHeight());
         const safeAreaInsets = this.getSafeAreaInsets();
-        const insetAllowance = utils.layout.toDeviceIndependentPixels(safeAreaInsets.left) * 2;
+        const insetAllowance = utils.layout.toDeviceIndependentPixels(safeAreaInsets.left + safeAreaInsets.right);
         const calculatedWidth = width + insetAllowance;
 
         // console.log(`_calcScrollViewContentSize ${calculatedWidth}, ${height}`);

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "grunt-contrib-clean": "1.0.0",
     "grunt-contrib-copy": "1.0.0",
     "grunt-exec": "2.0.0",
-    "tns-core-modules": "~4.0.1",
-    "tns-platform-declarations": "~4.0.0",
+    "tns-core-modules": "~5.0.0",
+    "tns-platform-declarations": "~5.0.0",
     "tslint": "5.2.0",
     "typescript": "^2.6.2"
   }


### PR DESCRIPTION
This fixes a bug on iPhones with Safe Area Insets (iPhone X, Xs, Xs max, etc.) where by just using `utils.layout.toDeviceIndependentPixels(this.getMeasuredWidth());` to calculate the width prevents you from scrolling completely through a group of image items.

For example, I had 14 images in my items and after scrolling to the 12th image, I was only able to scroll half way to the 13th image.

My fix involves using [getSafeAreaInsets()](https://docs.nativescript.org/api-reference/classes/_ui_core_view_.view#getsafeareainsets). On devices without Safe Area Insets, this will return `{ left: 0, top: 0, right: 0, bottom: 0 }`, but on devices with a Safe Are Inset these values will be > 0. On iPhone Xs max, the `left` is `132`. Running this through `utils.layout.toDeviceIndependentPixels()` on this device will result in `44`, which is half of the width we need to account for.

I'm not sure if Android would need a similar affordance. Maybe someone with more Android experience can weigh in.