### PR TITLE
Fix short imports deprecation 

### DIFF
--- a/demo-ng/app/vendor-platform.android.ts
+++ b/demo-ng/app/vendor-platform.android.ts
@@ -1,9 +1,9 @@
-require("application");
+require("tns-core-modules/application");
 if (!global["__snapshot"]) {
     // In case snapshot generation is enabled these modules will get into the bundle
     // but will not be required/evaluated.
     // The snapshot webpack plugin will add them to the tns-java-classes.js bundle file.
     // This way, they will be evaluated on app start as early as possible.
-    require("ui/frame");
-    require("ui/frame/activity");
+    require("tns-core-modules/ui/frame");
+    require("tns-core-modules/ui/frame/activity");
 }

--- a/demo-ng/app/vendor.ts
+++ b/demo-ng/app/vendor.ts
@@ -1,6 +1,6 @@
 // Snapshot the ~/app.css and the theme
-const application = require("application");
-require("ui/styling/style-scope");
+const application = require("tns-core-modules/application");
+require("tns-core-modules/ui/styling/style-scope");
 const appCssContext = require.context("~/", false, /^\.\/app\.(css|scss|less|sass)$/);
 global.registerWebpackModules(appCssContext);
 application.loadAppCss();

--- a/demo-ng/package-lock.json
+++ b/demo-ng/package-lock.json
@@ -2474,7 +2474,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2495,12 +2496,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2515,17 +2518,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2642,7 +2648,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2654,6 +2661,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2668,6 +2676,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2675,12 +2684,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2699,6 +2710,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2779,7 +2791,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2791,6 +2804,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2876,7 +2890,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2912,6 +2927,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2931,6 +2947,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2974,12 +2991,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/demo/app/app.ts
+++ b/demo/app/app.ts
@@ -5,7 +5,7 @@ purpose of the file is to pass control to the app’s first module.
 */
 
 import "./bundle-config";
-import * as app from 'application';
+import * as app from 'tns-core-modules/application';
 
 app.start({ moduleName: 'main-page' });
 

--- a/demo/app/main-page.ts
+++ b/demo/app/main-page.ts
@@ -1,6 +1,6 @@
-import { EventData, Observable } from "data/observable";
-import { ObservableArray } from "data/observable-array";
-import { Page } from "ui/page";
+import { EventData, Observable } from "tns-core-modules/data/observable";
+import { ObservableArray } from "tns-core-modules/data/observable-array";
+import { Page } from "tns-core-modules/ui/page";
 
 import { PageChangeEventData } from "nativescript-image-swipe";
 

--- a/demo/app/vendor-platform.android.ts
+++ b/demo/app/vendor-platform.android.ts
@@ -1,9 +1,9 @@
-require("application");
+require("tns-core-modules/application");
 if (!global["__snapshot"]) {
     // In case snapshot generation is enabled these modules will get into the bundle
     // but will not be required/evaluated.
     // The snapshot webpack plugin will add them to the tns-java-classes.js bundle file.
     // This way, they will be evaluated on app start as early as possible.
-    require("ui/frame");
-    require("ui/frame/activity");
+    require("tns-core-modules/ui/frame");
+    require("tns-core-modules/ui/frame/activity");
 }

--- a/demo/app/vendor.ts
+++ b/demo/app/vendor.ts
@@ -1,6 +1,6 @@
 // Snapshot the ~/app.css and the theme
-const application = require("application");
-require("ui/styling/style-scope");
+const application = require("tns-core-modules/application");
+require("tns-core-modules/ui/styling/style-scope");
 const appCssContext = require.context("~/", false, /^\.\/app\.(css|scss|less|sass)$/);
 global.registerWebpackModules(appCssContext);
 application.loadAppCss();

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -2310,7 +2310,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2331,12 +2332,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2351,17 +2354,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2478,7 +2484,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2490,6 +2497,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2504,6 +2512,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2511,12 +2520,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2535,6 +2546,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2615,7 +2627,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2627,6 +2640,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2712,7 +2726,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2748,6 +2763,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2767,6 +2783,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2810,12 +2827,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/image-swipe-common.ts
+++ b/image-swipe-common.ts
@@ -13,16 +13,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ***************************************************************************** */
-import { ObservableArray } from "data/observable-array";
-import { CSSType, CoercibleProperty, Property } from "ui/core/view";
-import { addWeakEventListener, removeWeakEventListener } from "ui/core/weak-event-listener";
-import { Cache } from "ui/image-cache";
-import { ItemsSource } from "ui/list-picker";
-import { ScrollView } from "ui/scroll-view";
+import { ObservableArray } from "tns-core-modules/data/observable-array";
+import { CSSType, CoercibleProperty, Property } from "tns-core-modules/ui/core/view";
+import { addWeakEventListener, removeWeakEventListener } from "tns-core-modules/ui/core/weak-event-listener";
+import { Cache } from "tns-core-modules/ui/image-cache";
+import { ItemsSource } from "tns-core-modules/ui/list-picker";
+import { ScrollView } from "tns-core-modules/ui/scroll-view";
 
 import { ImageSwipe as ImageSwipeDefinition } from ".";
 
-export * from "ui/scroll-view";
+export * from "tns-core-modules/ui/scroll-view";
 
 @CSSType("ImageSwipe")
 export abstract class ImageSwipeBase extends ScrollView implements ImageSwipeDefinition {

--- a/image-swipe.android.ts
+++ b/image-swipe.android.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ***************************************************************************** */
-import { GestureTypes } from "ui/gestures";
+import { GestureTypes } from "tns-core-modules/ui/gestures";
 import { ImageSwipeBase, allowZoomProperty, itemsProperty, pageNumberProperty } from "./image-swipe-common";
 
 // These constants specify the mode that we're in
@@ -82,7 +82,7 @@ export class ImageSwipe extends ImageSwipeBase {
         // Coerce selected index after we have set items to native view.
         pageNumberProperty.coerce(this);
     }
-    
+
     public [allowZoomProperty.setNative](value: boolean) {
         const currentImage = this.nativeView.findViewWithTag("Item" + this.pageNumber) as ZoomImageView;
         if (currentImage) {

--- a/image-swipe.d.ts
+++ b/image-swipe.d.ts
@@ -13,10 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ***************************************************************************** */
-import { EventData } from "data/observable";
-import { CoercibleProperty, Property } from "ui/core/view";
-import { ItemsSource } from "ui/list-picker";
-import { ScrollView } from "ui/scroll-view";
+import { EventData } from "tns-core-modules/data/observable";
+import { CoercibleProperty, Property } from "tns-core-modules/ui/core/view";
+import { ItemsSource } from "tns-core-modules/ui/list-picker";
+import { ScrollView } from "tns-core-modules/ui/scroll-view";
 
 export class ImageSwipe extends ScrollView {
     public static pageChangedEvent: string;

--- a/image-swipe.ios.ts
+++ b/image-swipe.ios.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ***************************************************************************** */
-import * as utils from "utils/utils";
+import * as utils from "tns-core-modules/utils/utils";
 import { ImageSwipeBase, allowZoomProperty, itemsProperty, pageNumberProperty } from "./image-swipe-common";
 
 export * from "./image-swipe-common";
@@ -83,7 +83,7 @@ export class ImageSwipe extends ImageSwipeBase {
 
         // Coerce selected index after we have set items to native view.
         pageNumberProperty.coerce(this);
-        
+
         if (this.pageNumber !== undefined && this.pageNumber !== null) {
             this._loadCurrentPage(this.pageNumber);
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-image-swipe",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Append the `tns-core-modules/` prefix to modules import to prevent errors on compilation due to short imports deprecation